### PR TITLE
Add dependencies to fix build with Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,17 @@
             <version>2.23.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.3</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
See https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist